### PR TITLE
No need to have text or html if there's a template set

### DIFF
--- a/src/main/kotlin/com/commit451/mailgun/SendMessageRequest.kt
+++ b/src/main/kotlin/com/commit451/mailgun/SendMessageRequest.kt
@@ -120,9 +120,6 @@ class SendMessageRequest internal constructor() {
         }
 
         fun build(): SendMessageRequest {
-            if (request.text == null && request.html == null) {
-                throw Exception("Need to specify text or html parameter")
-            }
             return request
         }
     }


### PR DESCRIPTION
There's no need to have TXT or HTML if there's a template specified.
So it's better not to limit the developer to put some text if there's no need to.